### PR TITLE
Fixed bug in function mergeWithNextNode(Node node)

### DIFF
--- a/src/org/megatherion/util/collections/UnrolledLinkedList.java
+++ b/src/org/megatherion/util/collections/UnrolledLinkedList.java
@@ -940,7 +940,7 @@ public class UnrolledLinkedList<E> extends AbstractList<E> implements List<E>, S
         if (next.next != null) {
             next.next.previous = node;
         }
-        node.next = next.next.next;
+        node.next = next.next;
         if (next == lastNode) {
             lastNode = node;
         }


### PR DESCRIPTION
Line 943 should be:

node.next = next.next; 

Currently, setting node.next to next.next.next will skip over one-too-many nodes. This results in losing a whole node's worth of data.